### PR TITLE
Added the option to set a computer_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "azurerm_windows_virtual_machine" "VM" {
   resource_group_name   = var.resource_group.name
   admin_username        = var.admin_username
   admin_password        = var.admin_password
-  computer_name         = local.vm-name
+  computer_name         = var.computer_name
   custom_data           = var.custom_data
   size                  = var.vm_size
   priority              = var.priority
@@ -163,7 +163,7 @@ resource "azurerm_windows_virtual_machine" "VM" {
       type = "SystemAssigned"
     }
   }
-  tags = local.tags
+  tags = merge(local.tags, [var.computer_name != null ? {"OsHostname" = var.computer_name} : null]...)
   lifecycle {
     ignore_changes = [
       # Ignore changes to username and password because it will require destroying and

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "postfix" {
   default     = ""
 }
 
+variable "computer_name" {
+  description = "(Optional) Desired OS hostname/NetBIOS for the VM"
+  type = string
+  default = null
+}
+
 variable "data_disks" {
   description = "Map of object of disk sizes in gigabytes and lun number for each desired data disks. See variable.tf file for example"
   type = map(object({


### PR DESCRIPTION
Added the option to set a different computer_name than the one for the Azure resource. 
A tag will be dynamically added if the computer_name is different than the name of the Azure Resource